### PR TITLE
ADD: cuda Defines

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -23,7 +23,7 @@ cudaDefines(const ParameterMap & parameter_list, const ConstantMap & constant_li
 static auto
 oclDefines(const ParameterMap & parameter_list, const ConstantMap & constant_list) -> std::string;
 
-static auto
+auto
 execute(const DevicePtr &    device,
         const KernelInfo &   kernel_func,
         const ParameterMap & parameters,

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -1,15 +1,101 @@
 #include "execution.hpp"
 
+#include <fstream>
+#include <string_view>
+#include <variant>
+
 namespace cle
 {
 
 static auto
 cudaDefines(const ParameterMap & parameter_list, const ConstantMap & constant_list) -> std::string
 {
-  // @StRigaud TODO: write cuda Defines to transform ocl Kernel into compatible cuda kernel
+  // @CherifMZ TODO: write cuda Defines to transform ocl Kernel into compatible cuda kernel
   // See
   // https://github.com/clEsperanto/pyclesperanto_prototype/blob/master/pyclesperanto_prototype/_tier0/_cuda_execute.py
-  return "";
+
+  std::ostringstream defines;
+  defines << "\n#define get_global_size(dim) global_size_ ## dim ## _size";
+  defines << "\n";
+
+  defines << "\n#define GET_IMAGE_WIDTH(image_key) IMAGE_SIZE_ ## image_key ## "
+             "_WIDTH";
+  defines << "\n#define GET_IMAGE_HEIGHT(image_key) IMAGE_SIZE_ ## image_key "
+             "## _HEIGHT";
+  defines << "\n#define GET_IMAGE_DEPTH(image_key) IMAGE_SIZE_ ## image_key ## "
+             "_DEPTH";
+  defines << "\n";
+
+  if (!constant_list.empty())
+  {
+    for (const auto & [key, value] : constant_list)
+    {
+      defines << "#define " << key << " " << value << "\n";
+    }
+    defines << "\n";
+  }
+
+  std::string size_params = "int global_size_0_size, int global_size_1_size, "
+                            "int global_size_2_size, ";
+
+  for (const auto & [key, value] : parameter_list)
+  {
+    if (std::holds_alternative<float>(value) || std::holds_alternative<int>(value))
+    {
+      continue;
+    }
+    const auto & arr = std::get<Array>(value);
+
+    std::string ndim;
+    std::string pos_type;
+    std::string pos;
+
+    std::string pixel_type;
+    std::string type_id;
+
+    if (arr.dim() < 3)
+    {
+      ndim = "2";
+      pos_type = "int2";
+      pos = "(pos0, pos1)";
+    }
+    else
+    {
+      ndim = "3";
+      pos_type = "int4";
+      pos = "(pos0, pos1, pos2, 0)";
+    }
+
+    std::string width = "image_" + key + "_width";
+    std::string height = "image_" + key + "_height";
+    std::string depth = "image_" + key + "_depth";
+
+    size_params = size_params + "int " + width + ", int " + height + ", int " + depth + ", ";
+
+    defines << "\n";
+    defines << "\n#define IMAGE_SIZE_" << key << "_WIDTH " << width;
+    defines << "\n#define IMAGE_SIZE_" << key << "_HEIGHT " << height;
+    defines << "\n#define IMAGE_SIZE_" << key << "_DEPTH " << depth;
+    defines << "\n";
+
+    defines << "\n";
+    defines << "\n#define CONVERT_" << key << "_PIXEL_TYPE clij_convert_" << arr.dtype() << "_sat";
+    defines << "\n#define IMAGE_" << key << "_PIXEL_TYPE " << arr.dtype() << "";
+    defines << "\n#define POS_" << key << "_TYPE " << pos_type;
+    defines << "\n#define POS_" << key << "_INSTANCE(pos0,pos1,pos2,pos3) make_" << pos_type << "" << pos;
+    defines << "\n";
+
+    defines << "\n";
+    defines << "\n#define IMAGE_" << key << "_TYPE " << size_params << "" << arr.dtype() << "*";
+    defines << "\n#define READ_" << key << "_IMAGE(a,b,c) read_buffer" << ndim << "d" << arr.shortType()
+            << "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)";
+    defines << "\n#define WRITE_" << key << "_IMAGE(a,b,c) write_buffer" << ndim << "d" << arr.shortType()
+            << "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)";
+    defines << "\n";
+  }
+
+  defines << "\n";
+  return defines.str();
 }
 
 static auto
@@ -127,7 +213,7 @@ oclDefines(const ParameterMap & parameter_list, const ConstantMap & constant_lis
   return defines.str();
 }
 
-static auto
+auto
 execute(const DevicePtr &    device,
         const KernelInfo &   kernel_func,
         const ParameterMap & parameters,
@@ -150,10 +236,13 @@ execute(const DevicePtr &    device,
       defines = cle::oclDefines(parameters, constants);
       break;
   }
-  std::string preamble = cle::BackendManager::getInstance().getBackend().getPreamble();
+
+  // getPreamble: not implemented yet
+  // std::string preamble = cle::BackendManager::getInstance().getBackend().getPreamble();
   std::string kernel = kernel_func.second;
   std::string func_name = kernel_func.first;
-  std::string source = defines + preamble + kernel;
+  // std::string source = defines + preamble + kernel;
+  std::string source = defines;
 
   // list kernel arguments and sizes
   for (const auto & [key, value] : parameters)
@@ -176,6 +265,17 @@ execute(const DevicePtr &    device,
       args_ptr.push_back(const_cast<int *>(&i));
       args_size.push_back(sizeof(int));
     }
+  }
+
+  // @CherifMZ: for TEST only, I added this chunk of code to write the content of the source into an external file
+  std::ofstream file("kernel_output.txt");
+  // Check if the file was opened successfully
+  if (file.is_open())
+  {
+    // Write the content to the file
+    file << source;
+    // Close the file
+    file.close();
   }
 
   // @StRigaud TODO: save source into file for debugging

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,13 @@ add_dependencies(push_pull_test ${LIBRARY_NAME})
 target_link_libraries(push_pull_test PRIVATE ${LIBRARY_NAME})
 set_target_properties(push_pull_test PROPERTIES FOLDER "Tests")
 
+add_executable(defines_test defines_test.cpp)
+add_dependencies(defines_test ${LIBRARY_NAME})
+target_link_libraries(defines_test PRIVATE ${LIBRARY_NAME})
+set_target_properties(defines_test PROPERTIES FOLDER "Tests")
+
 add_test(NAME backend_test COMMAND backend_test)
 add_test(NAME array_test COMMAND array_test)
 add_test(NAME image_test COMMAND image_test)
 add_test(NAME push_pull_test COMMAND push_pull_test)
+add_test(NAME defines_test COMMAND defines_test)

--- a/tests/defines_test.cpp
+++ b/tests/defines_test.cpp
@@ -1,0 +1,60 @@
+#include "array.hpp"
+#include "backendmanager.hpp"
+#include "device.hpp"
+#include "execution.hpp"
+#include "memory.hpp"
+#include "utils.hpp"
+#include <variant>
+
+
+void
+run_test()
+{
+
+  cle::BackendManager & backendManager = cle::BackendManager::getInstance();
+  auto                  device_list = backendManager.getBackend().getDevicesList("all");
+  std::cout << "Device list:" << std::endl;
+  for (auto && i : device_list)
+  {
+    std::cout << "\t" << i << std::endl;
+  }
+
+  auto device = backendManager.getBackend().getDevice("TX", "all");
+  std::cout << "Selected Device :" << device->getName() << std::endl;
+  std::cout << "Device Info :" << device->getInfo() << std::endl;
+  device->initialize();
+
+  static const size_t size = 5 * 5 * 2;
+  float *             data = new float[size];
+  for (int i = 0; i < size; i++)
+  {
+    data[i] = i;
+  }
+
+  cle::Array        gpu_arr(5, 5, 2, cle::dType::Float, cle::mType::Image, data, device);
+  cle::ParameterMap parameters;
+  cle::ConstantMap  constants{ { "CLK_NORMALIZED_COORDS_FALSE", 1 },
+                               { "CLK_ADDRESS_CLAMP_TO_EDGE", 2 },
+                               { "CLK_FILTER_NEAREST", 4 } };
+  cle::KernelInfo   kernel;
+  cle::RangeArray   global_rage;
+
+  parameters.emplace("src", gpu_arr);
+  parameters.emplace("dst", gpu_arr);
+
+  cle::execute(device, kernel, parameters, constants, global_rage);
+}
+
+int
+main(int argc, char ** argv)
+{
+  cle::BackendManager::getInstance().setBackend(false);
+  std::cout << cle::BackendManager::getInstance().getBackend().getType() << std::endl;
+  run_test();
+
+  cle::BackendManager::getInstance().setBackend(true);
+  std::cout << cle::BackendManager::getInstance().getBackend().getType() << std::endl;
+  run_test();
+
+  return 0;
+}


### PR DESCRIPTION
I have implemented a new version of Cuda Defines with its test.
When you execute the test, you get a file in which you can see the different definition parameters for Cuda and OpenCL written, depending on the device.