### PR TITLE
Add-output-creation-logic

### DIFF
--- a/include/tier0.hpp
+++ b/include/tier0.hpp
@@ -1,0 +1,37 @@
+#ifndef __INCLUDE_TIER0_HPP
+#define __INCLUDE_TIER0_HPP
+
+#include "array.hpp"
+#include "device.hpp"
+#include "execution.hpp"
+
+namespace cle::tier0
+{
+
+auto
+create_like(const Array::Pointer & src, Array::Pointer & dst) -> void;
+
+auto
+create_one(const Array::Pointer & src, Array::Pointer & dst) -> void;
+
+auto
+create_xy(const Array::Pointer & src, Array::Pointer & dst) -> void;
+
+auto
+create_yz(const Array::Pointer & src, Array::Pointer & dst) -> void;
+
+auto
+create_xz(const Array::Pointer & src, Array::Pointer & dst) -> void;
+
+auto
+execute_separable_func(const Device::Pointer &      device,
+                       const KernelInfo &           kernel,
+                       const Array::Pointer &       src,
+                       const Array::Pointer &       dst,
+                       const std::array<float, 3> & sigma,
+                       const std::array<int, 3> &   radius) -> void;
+
+
+} // namespace cle::tier0
+
+#endif // __INCLUDE_TIER0_HPP

--- a/include/tier1.hpp
+++ b/include/tier1.hpp
@@ -1,38 +1,30 @@
 #ifndef __INCLUDE_TIER1_HPP
 #define __INCLUDE_TIER1_HPP
 
-#include "array.hpp"
-#include "device.hpp"
-#include "execution.hpp"
+#include "tier0.hpp"
 
 namespace cle::tier1
 {
 
-auto
-execute_separable_func(const Device::Pointer & device,
-                       const KernelInfo &      kernel,
-                       const Array::Pointer &  src,
-                       const Array::Pointer &  dst,
-                       const float &           sigma,
-                       const int &             radius) -> void;
+
 auto
 gaussian_blur_func(const Device::Pointer & device,
                    const Array::Pointer &  src,
-                   const Array::Pointer &  dst,
+                   Array::Pointer          dst,
                    const float &           sigma_x,
                    const float &           sigma_y,
-                   const float &           sigma_z) -> void;
+                   const float &           sigma_z) -> Array::Pointer;
 
 auto
-absolute_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & dst) -> void;
+absolute_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
 
 auto
 add_images_weighted_func(const Device::Pointer & device,
                          const Array::Pointer &  src0,
                          const Array::Pointer &  src1,
-                         const Array::Pointer &  dst,
+                         Array::Pointer          dst,
                          const float &           factor0,
-                         const float &           factor1) -> void;
+                         const float &           factor1) -> Array::Pointer;
 
 } // namespace cle::tier1
 

--- a/include/tier2.hpp
+++ b/include/tier2.hpp
@@ -12,13 +12,13 @@ namespace cle::tier2
 auto
 difference_of_gaussian_func(const Device::Pointer & device,
                             const Array::Pointer &  src,
-                            const Array::Pointer &  dst,
+                            Array::Pointer          dst,
                             const float &           sigma1_x,
                             const float &           sigma1_y,
                             const float &           sigma1_z,
                             const float &           sigma2_x,
                             const float &           sigma2_y,
-                            const float &           sigma2_z) -> void;
+                            const float &           sigma2_z) -> Array::Pointer;
 
 } // namespace cle::tier2
 

--- a/src/tier0.cpp
+++ b/src/tier0.cpp
@@ -1,0 +1,106 @@
+
+#include "tier0.hpp"
+
+namespace cle::tier0
+{
+
+auto
+create_like(const Array::Pointer & src, Array::Pointer & dst) -> void
+{
+  if (dst != nullptr)
+  {
+    return;
+  }
+  dst = Array::create(src);
+}
+
+auto
+create_one(const Array::Pointer & src, Array::Pointer & dst) -> void
+{
+  if (dst != nullptr)
+  {
+    return;
+  }
+  dst = Array::create(1, 1, 1, src->dtype(), src->mtype(), src->device());
+}
+
+auto
+create_xy(const Array::Pointer & src, Array::Pointer & dst) -> void
+{
+  if (dst != nullptr)
+  {
+    return;
+  }
+  dst = Array::create(src->width(), src->height(), 1, src->dtype(), src->mtype(), src->device());
+}
+
+auto
+create_yz(const Array::Pointer & src, Array::Pointer & dst) -> void
+{
+  if (dst != nullptr)
+  {
+    return;
+  }
+  dst = Array::create(src->height(), src->depth(), 1, src->dtype(), src->mtype(), src->device());
+}
+
+auto
+create_xz(const Array::Pointer & src, Array::Pointer & dst) -> void
+{
+  if (dst != nullptr)
+  {
+    return;
+  }
+  dst = Array::create(src->width(), src->depth(), 1, src->dtype(), src->mtype(), src->device());
+}
+
+auto
+execute_separable_func(const Device::Pointer &      device,
+                       const KernelInfo &           kernel,
+                       const Array::Pointer &       src,
+                       const Array::Pointer &       dst,
+                       const std::array<float, 3> & sigma,
+                       const std::array<int, 3> &   radius) -> void
+{
+  const ConstantList constants = {};
+  const RangeArray   global_range = { dst->width(), dst->height(), dst->depth() };
+
+  auto tmp1 = Array::create(dst);
+  auto tmp2 = Array::create(dst);
+
+  if (dst->width() > 1 && sigma[0] > 0)
+  {
+    const ParameterList parameters = {
+      { "src", src }, { "dst", tmp1 }, { "dim", 0 }, { "N", radius[0] }, { "s", sigma[0] }
+    };
+    execute(device, kernel, parameters, constants, global_range);
+  }
+  else
+  {
+    src->copy(tmp1);
+  }
+  if (dst->height() > 1 && sigma[1] > 0)
+  {
+    const ParameterList parameters = {
+      { "src", tmp1 }, { "dst", tmp2 }, { "dim", 1 }, { "N", radius[1] }, { "s", sigma[1] }
+    };
+    execute(device, kernel, parameters, constants, global_range);
+  }
+  else
+  {
+    tmp1->copy(tmp2);
+  }
+  if (dst->depth() > 1 && sigma[2] > 0)
+  {
+    const ParameterList parameters = {
+      { "src", tmp2 }, { "dst", dst }, { "dim", 2 }, { "N", radius[2] }, { "s", sigma[2] }
+    };
+    execute(device, kernel, parameters, constants, global_range);
+  }
+  else
+  {
+    tmp2->copy(dst);
+  }
+}
+
+} // namespace cle

--- a/src/tier1.cpp
+++ b/src/tier1.cpp
@@ -1,4 +1,5 @@
 #include "tier1.hpp"
+#include "utils.hpp"
 
 #include "cle_absolute.h"
 #include "cle_add_images_weighted.h"
@@ -8,23 +9,26 @@ namespace cle::tier1
 {
 
 auto
-absolute_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & dst) -> void
+absolute_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
+  tier0::create_like(src, dst);
   const KernelInfo    kernel = { "absolute", kernel::absolute };
   const ConstantList  constants = {};
   const ParameterList parameters = { { "src", src }, { "dst", dst } };
   const RangeArray    global_range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, parameters, constants, global_range);
+  return dst;
 }
 
 auto
 add_images_weighted_func(const Device::Pointer & device,
                          const Array::Pointer &  src0,
                          const Array::Pointer &  src1,
-                         const Array::Pointer &  dst,
+                         Array::Pointer          dst,
                          const float &           factor0,
-                         const float &           factor1) -> void
+                         const float &           factor1) -> Array::Pointer
 {
+  tier0::create_like(src0, dst);
   const KernelInfo    kernel = { "add_images_weighted", kernel::add_images_weighted };
   const ConstantList  constants = {};
   const ParameterList parameters = {
@@ -32,72 +36,26 @@ add_images_weighted_func(const Device::Pointer & device,
   };
   const RangeArray global_range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, parameters, constants, global_range);
-}
-
-auto
-execute_separable_func(const Device::Pointer &      device,
-                       const KernelInfo &           kernel,
-                       const Array::Pointer &       src,
-                       const Array::Pointer &       dst,
-                       const std::array<float, 3> & sigma,
-                       const std::array<int, 3> &   radius) -> void
-{
-  const ConstantList constants = {};
-  const RangeArray   global_range = { dst->width(), dst->height(), dst->depth() };
-
-  auto tmp1 = Array::create(dst);
-  auto tmp2 = Array::create(dst);
-
-  if (dst->width() > 1 && sigma[0] > 0)
-  {
-    const ParameterList parameters = {
-      { "src", src }, { "dst", tmp1 }, { "dim", 0 }, { "N", radius[0] }, { "s", sigma[0] }
-    };
-    execute(device, kernel, parameters, constants, global_range);
-  }
-  else
-  {
-    src->copy(tmp1);
-  }
-  if (dst->height() > 1 && sigma[1] > 0)
-  {
-    const ParameterList parameters = {
-      { "src", tmp1 }, { "dst", tmp2 }, { "dim", 1 }, { "N", radius[1] }, { "s", sigma[1] }
-    };
-    execute(device, kernel, parameters, constants, global_range);
-  }
-  else
-  {
-    tmp1->copy(tmp2);
-  }
-  if (dst->depth() > 1 && sigma[2] > 0)
-  {
-    const ParameterList parameters = {
-      { "src", tmp2 }, { "dst", dst }, { "dim", 2 }, { "N", radius[2] }, { "s", sigma[2] }
-    };
-    execute(device, kernel, parameters, constants, global_range);
-  }
-  else
-  {
-    tmp2->copy(dst);
-  }
+  return dst;
 }
 
 auto
 gaussian_blur_func(const Device::Pointer & device,
                    const Array::Pointer &  src,
-                   const Array::Pointer &  dst,
+                   Array::Pointer          dst,
                    const float &           sigma_x,
                    const float &           sigma_y,
-                   const float &           sigma_z) -> void
+                   const float &           sigma_z) -> Array::Pointer
 {
+  tier0::create_like(src, dst);
   const KernelInfo kernel = { "gaussian_blur_separable", kernel::gaussian_blur_separable };
-  execute_separable_func(device,
-                         kernel,
-                         src,
-                         dst,
-                         { sigma_x, sigma_y, sigma_z },
-                         { sigma2radius(sigma_x), sigma2radius(sigma_y), sigma2radius(sigma_z) });
+  tier0::execute_separable_func(device,
+                                kernel,
+                                src,
+                                dst,
+                                { sigma_x, sigma_y, sigma_z },
+                                { sigma2radius(sigma_x), sigma2radius(sigma_y), sigma2radius(sigma_z) });
+  return dst;
 }
 
 } // namespace cle::tier1

--- a/src/tier2.cpp
+++ b/src/tier2.cpp
@@ -1,4 +1,5 @@
 #include "tier2.hpp"
+#include "tier0.hpp"
 #include "tier1.hpp"
 
 namespace cle::tier2
@@ -7,19 +8,21 @@ namespace cle::tier2
 auto
 difference_of_gaussian_func(const Device::Pointer & device,
                             const Array::Pointer &  src,
-                            const Array::Pointer &  dst,
+                            Array::Pointer          dst,
                             const float &           sigma1_x,
                             const float &           sigma1_y,
                             const float &           sigma1_z,
                             const float &           sigma2_x,
                             const float &           sigma2_y,
-                            const float &           sigma2_z) -> void
+                            const float &           sigma2_z) -> Array::Pointer
 {
+  tier0::create_like(src, dst);
   auto gauss1 = Array::create(dst);
   auto gauss2 = Array::create(dst);
   tier1::gaussian_blur_func(device, src, gauss1, sigma1_x, sigma1_y, sigma1_z);
   tier1::gaussian_blur_func(device, src, gauss2, sigma2_x, sigma2_y, sigma2_z);
   tier1::add_images_weighted_func(device, gauss1, gauss2, dst, 1, -1);
+  return dst;
 }
 
 } // namespace cle::tier2

--- a/tests/absolute_test.cpp
+++ b/tests/absolute_test.cpp
@@ -21,11 +21,9 @@ run_absolute(cle::mType type) -> bool
   std::vector<T>      valid(w * h * d, 5);
 
   auto gpu_input = cle::Array::create(w, h, d, cle::toType<T>(), type, input.data(), device);
-  auto gpu_output = cle::Array::create(gpu_input);
-
-  cle::tier1::absolute_func(device, gpu_input, gpu_output);
-
+  auto gpu_output = cle::tier1::absolute_func(device, gpu_input, nullptr);
   gpu_output->read(output.data());
+
   return std::equal(output.begin(), output.end(), valid.begin()) ? 0 : 1;
 }
 

--- a/tests/difference_of_gaussian_test.cpp
+++ b/tests/difference_of_gaussian_test.cpp
@@ -40,9 +40,7 @@ run_gaussian_blur(const cle::mType & type) -> bool
   //           static_cast<T>(0.2915041744709014892578125F) };
 
   auto gpu_input = cle::Array::create(w, h, d, cle::toType<T>(), type, input.data(), device);
-  auto gpu_output = cle::Array::create(w, h, d, cle::toType<T>(), type, device);
-  cle::tier2::difference_of_gaussian_func(device, gpu_input, gpu_output, 1, 1, 1, 2, 2, 2);
-
+  auto gpu_output = cle::tier2::difference_of_gaussian_func(device, gpu_input, nullptr, 1, 1, 1, 2, 2, 2);
   gpu_output->read(output.data());
 
   return std::equal(output.begin(), output.end(), valid.begin()) ? 0 : 1;

--- a/tests/gaussian_test.cpp
+++ b/tests/gaussian_test.cpp
@@ -40,10 +40,7 @@ run_gaussian_blur(const cle::mType & type) -> bool
 
 
   auto gpu_input = cle::Array::create(w, h, d, cle::toType<T>(), type, input.data(), device);
-  auto gpu_output = cle::Array::create(w, h, d, cle::toType<T>(), type, device);
-
-  cle::tier1::gaussian_blur_func(device, gpu_input, gpu_output, 1, 1, 1);
-
+  auto gpu_output = cle::tier1::gaussian_blur_func(device, gpu_input, nullptr, 1, 1, 1);
   gpu_output->read(output.data());
 
   return std::equal(output.begin(), output.end(), valid.begin()) ? 0 : 1;


### PR DESCRIPTION
output in kernel call are now optional.

they can be replaced by `nullptr`

```cpp
auto output = cle::tier1::absolute_func(device, input, nullptr);
```

if no `output` is provided then we can create one using one of the `tier0` function.
Each kernel function call now return the output.

See tests for application